### PR TITLE
Update README, Makefile to allow flashing the keyboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ backup:
 	@DEVICE=${DEVICE_PORT} ${FOCUS_TOOL} eeprom.contents >${BACKUP_FILE}
 
 prompt:
-	@echo "Please double-press the reset button on the Neuron, then press ENTER"
+	@echo "Please put you Raise in flashing mode by disconnecting the neuron, pressing and holding the ESC key while reconnecting the keyboard without releasing ESC. Wait for a blue led effect to appear in the Neuron. Then continue."
 	-$(PS)
 
 win_prompt:

--- a/README.md
+++ b/README.md
@@ -81,12 +81,18 @@ make config
 ```
 Will show the current configuration of the makefile.
 
-Modify it to fit your current environment.
+Modify it to fit your current environment, you probably need to change the `DEVICE_PORT`.
 
 #### Run the make file
 ```sh
 cd Raise-Firmware
+
+# Now put you Raise in flashing mode by disconnecting the neuron from the PC, pressing ESC physical key
+# and then reconnecting the keyboard to the PC without releasing ESC, lastly wait for a blue led effect 
+# to appear in the Neuron.
+
 make flash
+# Disconnect the keyboard and plug it in again (just to be safe, should not be necessary).
 ```
 ## Option 2: From the Arduino IDE
 


### PR DESCRIPTION
So far this information has been only in the Makefile.MD and it's absolutely crucial to get make flash to work. Took me quite some hours to figure this out, hope this saves someone else some time.

I'm not sure if the Makefile prompt has still been useful for very old firmware versions? But for me it wasn't really helpful. Also it conflicts with the information in the Makefile.MD